### PR TITLE
9th month in Spanish, alias

### DIFF
--- a/monthnames.json
+++ b/monthnames.json
@@ -1048,6 +1048,7 @@
     "es": {
         "julio": 7,
         "septiembre": 9,
+        "setiembre": 9,
         "marzo": 3,
         "junio": 6,
         "abril": 4,


### PR DESCRIPTION
"setiembre", the same as "septiembre". See <http://dle.rae.es/?id=Xk42Bqw>.