### PR TITLE
resolve namespace prefixes in wikitext

### DIFF
--- a/main.js
+++ b/main.js
@@ -872,7 +872,7 @@ function proceedOnePage() {
 
 function createCheckboxlist(pageids) {
     for (var j in pageids) {
-        $('#result').append('<div><input type="checkbox" name="pagelist" id="' + pageids[j][0] + '" data-qid="' + pageids[j][1] + '" checked><span><a href="//' + job.siteid + '.' + job.project + '.org/wiki/' + encodeURIComponent(namespaces[job.namespace] + ':' + pageids[j][2]) + '" target="_blank">' + escapeHTML(pageids[j][2].replace(/_/g, ' ')) + '</a></span></div>');
+        $('#result').append('<div><input type="checkbox" name="pagelist" id="' + pageids[j][0] + '" data-qid="' + pageids[j][1] + '" checked><span><a href="//' + job.siteid + '.' + job.project + '.org/wiki/' + encodeURIComponent(namespaces[job.namespace]) + ':' + encodeURIComponent(pageids[j][2]) + '" target="_blank">' + escapeHTML(pageids[j][2].replace(/_/g, ' ')) + '</a></span></div>');
     }
     $('#addvalues').show();
     $('#demo').show();

--- a/main.js
+++ b/main.js
@@ -675,9 +675,7 @@ function handleValue(pageid, qid, value) {
         }
         checkForInterwiki(pageid, qid, res, 'https://' + job.siteid + '.' + job.project + '.org');
     } else if (job.datatype == 'commonsMedia') {
-        for (var i in fileprefixes) {
-            value = value.replace(new RegExp('^' + fileprefixes[i] + ':\\s*', 'i'), '');
-        }
+        value = value.replace(new RegExp('^(' + fileprefixes.join('|') + '):\\s*', 'i'), '');
         value = decodeURIComponent(value.replace(/_/g, ' ').replace(/\s+/g, ' ').trim());
         checkConstraints(pageid, qid, value, 0);
     } else if (job.datatype == 'time') {

--- a/main.js
+++ b/main.js
@@ -692,6 +692,10 @@ function handleValue(pageid, qid, value) {
         }
         checkForInterwiki(pageid, qid, res, 'https://' + job.siteid + '.' + job.project + '.org');
     } else if (job.datatype == 'commonsMedia') {
+        var res = value.match(/\[\[([^\|\]]+)/);
+        if (res !== null) {
+            value = res[1];
+        }
         value = value.replace(new RegExp('^(' + fileprefixes.join('|') + '):\\s*', 'i'), '');
         value = decodeURIComponent(value.replace(/_/g, ' ').replace(/\s+/g, ' ').trim());
         checkConstraints(pageid, qid, value, 0);

--- a/main.js
+++ b/main.js
@@ -220,13 +220,11 @@ function loadSiteinfo() {
         format: 'json'
     }).done(function(data) {
         namespaces = {};
-        fileprefixes = ['File'];
-        templateprefixes = ['Template'];
         for (var ns in data.query.namespaces) {
             namespaces[ns] = data.query.namespaces[ns]['*'];
         }
-        fileprefixes.push(namespaces[6]);
-        templateprefixes.push(namespaces[10]);
+        fileprefixes = ['File', namespaces[6]];
+        templateprefixes = ['Template', namespaces[10]];
         for (var i in data.query.namespacealiases) {
             if (data.query.namespacealiases[i].id == 6) {
                 fileprefixes.push(data.query.namespacealiases[i]['*']);


### PR DESCRIPTION
- initializing job now involves loading siteinfo with namespace names and their aliases, so id-to-namespace map needs no longer to be hardcoded (which caused troubles eg. with "Author:" × "Portal:" namespaces)
- "Commons link" constraint now loads the target namespace id as "missing constraint data"
- when parsing template, "Template:" and similar prefixes are removed
- when parsing file, "File:" and similar prefixes are removed