### PR TITLE
fix #115

### DIFF
--- a/index.php
+++ b/index.php
@@ -193,7 +193,7 @@
                 </div>
             </div>
         </form>
-        <div class="rightbox"><a class="permalink" style="display:none;" href="#">Permalink</a><span id="downloadlinks" style="display:none;"> | download <a class="download" href="#">CSV</a> | <a class="download" href="#">TSV</a></span></div>
+        <div class="rightbox"><a class="permalink" style="display:none;" href="#" target="_blank">Permalink</a><span id="downloadlinks" style="display:none;"> | download <a class="download" href="#">CSV</a> | <a class="download" href="#">TSV</a></span></div>
         <div id="result"></div>
     </div>
 

--- a/main.js
+++ b/main.js
@@ -1183,16 +1183,16 @@ $(document).ready(function() {
         showAdditionalFields();
     });
 
-    $('.permalink').click(function(e) {
+    $('.permalink').mouseover(function() {
         var url = '//tools.wmflabs.org/pltools/harvesttemplates/?';
         var params = $( 'form input:visible, form select:visible' ).serializeArray();
         $('form input[type=checkbox]:not(:checked)').each(function() {
-            params.push({name: this.name, value: '0' });
+            params.push({ name: this.name, value: '0' });
         });
         $.each( params, function( i, field ) {
             url += field.name+'='+field.value+'&';
         });
-        window.open(url);
+        $(this).attr('href', url);
     });
 
     $('.download').click(function(e) {

--- a/main.js
+++ b/main.js
@@ -1183,7 +1183,7 @@ $(document).ready(function() {
         showAdditionalFields();
     });
 
-    $('.permalink').mouseover(function() {
+    $('.permalink').mouseenter(function() {
         var url = '//tools.wmflabs.org/pltools/harvesttemplates/?';
         var params = $( 'form input:visible, form select:visible' ).serializeArray();
         $('form input[type=checkbox]:not(:checked)').each(function() {


### PR DESCRIPTION
The link's target is now generated whenever the user hovers the mouse over the link, so that they can copy it via right-click.